### PR TITLE
KHAF-50 로그인 기능 구현

### DIFF
--- a/src/main/java/kr/co/iei/member/controller/MemberController.java
+++ b/src/main/java/kr/co/iei/member/controller/MemberController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import kr.co.iei.member.model.dto.LoginMemberDTO;
 import kr.co.iei.member.model.dto.MemberDTO;
 import kr.co.iei.member.model.service.MemberService;
 
@@ -45,9 +46,21 @@ public class MemberController {
 	}
 	
 	//비밀번호 재설정
-	@PatchMapping(value="/updatrePw")
-	public ResponseEntity<Integer> updatePw(@PathVariable MemberDTO member){
+	@PatchMapping(value="/updatePw")
+	public ResponseEntity<Integer> updatePw(@RequestBody MemberDTO member){
+		System.out.println(member);
 		int result = memberService.updatePw(member);
 		return ResponseEntity.ok(result);
+	}
+	
+	//로그인
+	@PostMapping(value="/login")
+	public ResponseEntity<LoginMemberDTO> login(@RequestBody MemberDTO member){
+		LoginMemberDTO loginMember = memberService.login(member);
+		if(loginMember != null) {
+			return ResponseEntity.ok(loginMember);
+		}else {
+			return ResponseEntity.status(404).build();
+		}
 	}
 }

--- a/src/main/java/kr/co/iei/member/model/dao/MemberDao.java
+++ b/src/main/java/kr/co/iei/member/model/dao/MemberDao.java
@@ -14,4 +14,6 @@ public interface MemberDao {
 	int existsEmail(String memberEmail);
 
 	int updatePw(MemberDTO member);
+
+	MemberDTO selectOneMember(String memberEmail);
 }

--- a/src/main/java/kr/co/iei/member/model/dto/LoginMemberDTO.java
+++ b/src/main/java/kr/co/iei/member/model/dto/LoginMemberDTO.java
@@ -11,5 +11,6 @@ public class LoginMemberDTO {
 	private String accessToken;
 	private String refreshToken;
 	private String memberEmail;
+	private String memberNickname;
 	private int memberType;
 }

--- a/src/main/java/kr/co/iei/member/model/dto/MemberDTO.java
+++ b/src/main/java/kr/co/iei/member/model/dto/MemberDTO.java
@@ -21,4 +21,5 @@ public class MemberDTO {
 	private String profileImg;
 	private int memberLevel;
 	private String memberDel;
+	private int memberType;
 }

--- a/src/main/java/kr/co/iei/member/model/service/MemberService.java
+++ b/src/main/java/kr/co/iei/member/model/service/MemberService.java
@@ -10,6 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import kr.co.iei.member.model.dao.MemberDao;
+import kr.co.iei.member.model.dto.LoginMemberDTO;
 import kr.co.iei.member.model.dto.MemberDTO;
 import kr.co.iei.util.JwtUtils;
 
@@ -46,7 +47,23 @@ public class MemberService {
 
     //비밀번호 재설정
 	public int updatePw(MemberDTO member) {
+		String encPw = encoder.encode(member.getMemberPw());
+		member.setMemberPw(encPw);
 		int result = memberDao.updatePw(member);
 		return result;
+	}
+
+	public LoginMemberDTO login(MemberDTO member) {
+
+		MemberDTO m = memberDao.selectOneMember(member.getMemberEmail());
+		if(m != null && encoder.matches(member.getMemberPw(), m.getMemberPw())) {
+			String accessToken = jwtUtil.createAccessToken(m.getMemberEmail(), m.getMemberType());
+			System.out.println("accessToken : "+accessToken);
+			String refreshToken = jwtUtil.createRefreshToken(m.getMemberEmail(),m.getMemberType());
+			LoginMemberDTO loginMember = new LoginMemberDTO(accessToken, refreshToken, m.getMemberEmail(), m.getMemberType());
+			System.out.println(loginMember);
+			return loginMember;
+		}
+		return null;
 	}
 }

--- a/src/main/java/kr/co/iei/member/model/service/MemberService.java
+++ b/src/main/java/kr/co/iei/member/model/service/MemberService.java
@@ -60,7 +60,7 @@ public class MemberService {
 			String accessToken = jwtUtil.createAccessToken(m.getMemberEmail(), m.getMemberType());
 			System.out.println("accessToken : "+accessToken);
 			String refreshToken = jwtUtil.createRefreshToken(m.getMemberEmail(),m.getMemberType());
-			LoginMemberDTO loginMember = new LoginMemberDTO(accessToken, refreshToken, m.getMemberEmail(), m.getMemberType());
+			LoginMemberDTO loginMember = new LoginMemberDTO(accessToken, refreshToken, m.getMemberEmail(), m.getMemberNickname(), m.getMemberType());
 			System.out.println(loginMember);
 			return loginMember;
 		}

--- a/src/main/java/kr/co/iei/tour/controller/TourController.java
+++ b/src/main/java/kr/co/iei/tour/controller/TourController.java
@@ -7,10 +7,12 @@ import java.util.List;
 import org.jsoup.Jsoup;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@CrossOrigin("*")
 @RestController
 @RequestMapping(value="/tour")
 public class TourController {

--- a/src/main/java/kr/co/iei/util/EmailSender.java
+++ b/src/main/java/kr/co/iei/util/EmailSender.java
@@ -15,7 +15,7 @@ import jakarta.mail.internet.MimeMessage;
 
 @Component
 public class EmailSender {
-	
+	@Autowired
 	private JavaMailSender sender;
 	
 	public void sendMail(String emailTitle, String receiver, String emailContent) {

--- a/src/main/resources/mapper/member-mapper.xml
+++ b/src/main/resources/mapper/member-mapper.xml
@@ -25,6 +25,10 @@
 	</insert>
 	
 	<update id="updatePw">
-		update member set member_pw where member_email = #{memberEmail}
+		update member set member_pw = #{memberPw} where member_email = #{memberEmail}
 	</update>
+	
+	<select id="selectOneMember" resultType="member">
+		select * from member where member_email= #{memberEmail}
+	</select>
 </mapper>


### PR DESCRIPTION
 ## ✨ 작업 내용 

1. 로그인 기능
2. 새 비밀번호 설정

memberEmail 을 받아 해당 계정의 memberPw를 가져와 BCryptPasswordEncoder 의 encoder 로 기존 암호와 matches 시켜 같으면 로그인으로 처리
jwt 객체 생성 후, 토큰 발행

인증받은 이메일에 대하여 새 비밀번호를 입력받고 BCryptPasswordEncoder 의 encoder로 암호화한 후 update set memberPw 함


 ## 🐞 완료한 하위 이슈 및 진행상황

 KHAF-50 회원가입(70%)

 KHAF-50 로그인(70%)

 KHAF-50 새 비밀번호 설정(70%)

소셜로그인 남음